### PR TITLE
fix off-by-one in default load strategy

### DIFF
--- a/src/Sempare.Template.TemplateRegistry.pas
+++ b/src/Sempare.Template.TemplateRegistry.pas
@@ -291,7 +291,7 @@ begin
 {$ELSE}
   FRefreshIntervalS := 10;
   setlength(FLoadStrategy, 1);
-  FLoadStrategy[1] := tlsLoadResource;
+  FLoadStrategy[0] := tlsLoadResource;
   AutomaticRefresh := false;
 {$ENDIF}
 end;


### PR DESCRIPTION
The release mode build of TTemplateRegistry had a small off-by-one issue and tried to assign the load strategy to the second element of the FLoadStrategy array with length 1.
